### PR TITLE
Update ResScalarValue.java

### DIFF
--- a/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResScalarValue.java
+++ b/brut.apktool/apktool-lib/src/main/java/brut/androlib/res/data/value/ResScalarValue.java
@@ -74,6 +74,13 @@ public abstract class ResScalarValue extends ResIntBasedValue implements
 
         String body = encodeAsResXmlValue();
 
+        //id should not have content
+        //but every now and then there is something, explained by this
+        //https://stackoverflow.com/a/26073822/2527077
+        if ( "id".equals ( type ) && body != null && !body.isEmpty () ) {
+            body = "";
+        }
+
         // check for resource reference
         if (!type.equalsIgnoreCase("color")) {
             if (body.contains("@")) {


### PR DESCRIPTION
aapt2 rules prevent building.
So the choice is simple either fix here or loosen rules in aapt2.
For now here....?
Not sure this is the best place for this, as I can not quite pin point where the res value is being streamed into the res table. It would be better to catch at source not filter at output.
Related to Issue 1918 and 1909